### PR TITLE
Cleaned up pin descriptions on a few components

### DIFF
--- a/SparkFun-Boards.lbr
+++ b/SparkFun-Boards.lbr
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="6.5.0">
+<eagle version="6.4">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.05" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.025" altunitdist="inch" altunit="inch"/>
+<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.01" altunitdist="inch" altunit="inch"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="16" name="Bottom" color="1" fill="1" visible="yes" active="yes"/>
@@ -3141,12 +3141,12 @@ AudioAmp</text>
 <pin name="A2" x="12.7" y="0" length="short" rot="R180"/>
 <pin name="A3" x="12.7" y="2.54" length="short" rot="R180"/>
 <pin name="GND" x="-10.16" y="5.08" length="short"/>
-<pin name="GND2" x="12.7" y="10.16" length="short" rot="R180"/>
+<pin name="GND@2" x="12.7" y="10.16" length="short" rot="R180"/>
 <pin name="RAW" x="12.7" y="12.7" length="short" rot="R180"/>
 <pin name="RST" x="-10.16" y="7.62" length="short"/>
-<pin name="RST2" x="12.7" y="7.62" length="short" rot="R180"/>
-<pin name="RX1" x="-10.16" y="10.16" length="short"/>
-<pin name="TX0" x="-10.16" y="12.7" length="short"/>
+<pin name="RST@2" x="12.7" y="7.62" length="short" rot="R180"/>
+<pin name="RXI" x="-10.16" y="10.16" length="short"/>
+<pin name="TXO" x="-10.16" y="12.7" length="short"/>
 <pin name="VCC" x="12.7" y="5.08" length="short" rot="R180"/>
 </symbol>
 <symbol name="ARDUINO_SHIELD">
@@ -3355,15 +3355,15 @@ AudioAmp</text>
 <text x="-7.62" y="18.542" size="1.778" layer="95">&gt;NAME</text>
 <text x="-7.62" y="-25.4" size="1.778" layer="96">&gt;VALUE</text>
 <pin name="2" x="-10.16" y="5.08" length="short"/>
-<pin name="3" x="-10.16" y="2.54" length="short"/>
+<pin name="*3" x="-10.16" y="2.54" length="short"/>
 <pin name="4" x="-10.16" y="0" length="short"/>
-<pin name="5" x="-10.16" y="-2.54" length="short"/>
-<pin name="6" x="-10.16" y="-5.08" length="short"/>
+<pin name="*5" x="-10.16" y="-2.54" length="short"/>
+<pin name="*6" x="-10.16" y="-5.08" length="short"/>
 <pin name="7" x="-10.16" y="-7.62" length="short"/>
 <pin name="8" x="-10.16" y="-10.16" length="short"/>
-<pin name="9" x="-10.16" y="-12.7" length="short"/>
-<pin name="10" x="12.7" y="-12.7" length="short" rot="R180"/>
-<pin name="11" x="12.7" y="-10.16" length="short" rot="R180"/>
+<pin name="*9" x="-10.16" y="-12.7" length="short"/>
+<pin name="*10" x="12.7" y="-12.7" length="short" rot="R180"/>
+<pin name="*11" x="12.7" y="-10.16" length="short" rot="R180"/>
 <pin name="12" x="12.7" y="-7.62" length="short" rot="R180"/>
 <pin name="13" x="12.7" y="-5.08" length="short" rot="R180"/>
 <pin name="A0" x="12.7" y="-2.54" length="short" rot="R180"/>
@@ -3371,12 +3371,12 @@ AudioAmp</text>
 <pin name="A2" x="12.7" y="2.54" length="short" rot="R180"/>
 <pin name="A3" x="12.7" y="5.08" length="short" rot="R180"/>
 <pin name="GND" x="-10.16" y="7.62" length="short"/>
-<pin name="GND2" x="12.7" y="12.7" length="short" rot="R180"/>
+<pin name="GND@2" x="12.7" y="12.7" length="short" rot="R180"/>
 <pin name="RAW" x="12.7" y="15.24" length="short" rot="R180"/>
 <pin name="RST" x="-10.16" y="10.16" length="short"/>
-<pin name="RST2" x="12.7" y="10.16" length="short" rot="R180"/>
-<pin name="RX1" x="-10.16" y="12.7" length="short"/>
-<pin name="TX0" x="-10.16" y="15.24" length="short"/>
+<pin name="RST@2" x="12.7" y="10.16" length="short" rot="R180"/>
+<pin name="RXI" x="-10.16" y="12.7" length="short"/>
+<pin name="TXO" x="-10.16" y="15.24" length="short"/>
 <pin name="VCC" x="12.7" y="7.62" length="short" rot="R180"/>
 <pin name="A7" x="12.7" y="-17.78" length="short" rot="R180"/>
 <pin name="A6" x="12.7" y="-20.32" length="short" rot="R180"/>
@@ -3388,7 +3388,7 @@ AudioAmp</text>
 <pin name="HV_TXO_1" x="7.62" y="30.48" length="middle" rot="R180"/>
 <pin name="HV_RXI_1" x="7.62" y="27.94" length="middle" rot="R180"/>
 <pin name="HV" x="7.62" y="25.4" length="middle" rot="R180"/>
-<pin name="GND2" x="7.62" y="22.86" length="middle" rot="R180"/>
+<pin name="GND@2" x="7.62" y="22.86" length="middle" rot="R180"/>
 <pin name="HV_RXI_2" x="7.62" y="20.32" length="middle" rot="R180"/>
 <pin name="HV_TXO_2" x="7.62" y="17.78" length="middle" rot="R180"/>
 <pin name="LV_TXI_1" x="-30.48" y="30.48" length="middle"/>
@@ -3448,14 +3448,14 @@ AudioAmp</text>
 <text x="-7.62" y="18.542" size="1.778" layer="95">&gt;NAME</text>
 <text x="-7.62" y="-17.78" size="1.778" layer="96">&gt;VALUE</text>
 <pin name="2" x="-10.16" y="5.08" length="short"/>
-<pin name="3" x="-10.16" y="2.54" length="short"/>
+<pin name="*3" x="-10.16" y="2.54" length="short"/>
 <pin name="4" x="-10.16" y="0" length="short"/>
-<pin name="5" x="-10.16" y="-2.54" length="short"/>
-<pin name="6" x="-10.16" y="-5.08" length="short"/>
+<pin name="*5" x="-10.16" y="-2.54" length="short"/>
+<pin name="*6" x="-10.16" y="-5.08" length="short"/>
 <pin name="7" x="-10.16" y="-7.62" length="short"/>
 <pin name="8" x="-10.16" y="-10.16" length="short"/>
-<pin name="9" x="-10.16" y="-12.7" length="short"/>
-<pin name="10" x="12.7" y="-12.7" length="short" rot="R180"/>
+<pin name="*9" x="-10.16" y="-12.7" length="short"/>
+<pin name="*10" x="12.7" y="-12.7" length="short" rot="R180"/>
 <pin name="11(MOSI)" x="12.7" y="-10.16" length="short" rot="R180"/>
 <pin name="12(MISO)" x="12.7" y="-7.62" length="short" rot="R180"/>
 <pin name="13(SCK)" x="12.7" y="-5.08" length="short" rot="R180"/>
@@ -3464,12 +3464,12 @@ AudioAmp</text>
 <pin name="A2" x="12.7" y="2.54" length="short" rot="R180"/>
 <pin name="A3" x="12.7" y="5.08" length="short" rot="R180"/>
 <pin name="GND" x="-10.16" y="7.62" length="short"/>
-<pin name="GND2" x="12.7" y="12.7" length="short" rot="R180"/>
+<pin name="GND@2" x="12.7" y="12.7" length="short" rot="R180"/>
 <pin name="RAW" x="12.7" y="15.24" length="short" rot="R180"/>
-<pin name="GND1" x="-10.16" y="10.16" length="short"/>
+<pin name="GND@1" x="-10.16" y="10.16" length="short"/>
 <pin name="RESET" x="12.7" y="10.16" length="short" rot="R180"/>
 <pin name="RXI" x="-10.16" y="12.7" length="short"/>
-<pin name="TX0" x="-10.16" y="15.24" length="short"/>
+<pin name="TXO" x="-10.16" y="15.24" length="short"/>
 <pin name="VCC" x="12.7" y="7.62" length="short" rot="R180"/>
 <wire x1="-7.62" y1="-15.24" x2="10.16" y2="-15.24" width="0.254" layer="94"/>
 </symbol>
@@ -3686,12 +3686,12 @@ AudioAmp</text>
 <connect gate="G$1" pin="A2" pad="19"/>
 <connect gate="G$1" pin="A3" pad="20"/>
 <connect gate="G$1" pin="GND" pad="4"/>
-<connect gate="G$1" pin="GND2" pad="23"/>
+<connect gate="G$1" pin="GND@2" pad="23"/>
 <connect gate="G$1" pin="RAW" pad="24"/>
 <connect gate="G$1" pin="RST" pad="3"/>
-<connect gate="G$1" pin="RST2" pad="22"/>
-<connect gate="G$1" pin="RX1" pad="2"/>
-<connect gate="G$1" pin="TX0" pad="1"/>
+<connect gate="G$1" pin="RST@2" pad="22"/>
+<connect gate="G$1" pin="RXI" pad="2"/>
+<connect gate="G$1" pin="TXO" pad="1"/>
 <connect gate="G$1" pin="VCC" pad="21"/>
 </connects>
 <technologies>
@@ -4137,18 +4137,18 @@ See http://www.sparkfun.com/commerce/product_info.php?products_id=9473 for more 
 <devices>
 <device name="" package="ARDUINO_PRO_MINI">
 <connects>
-<connect gate="G$1" pin="10" pad="13"/>
-<connect gate="G$1" pin="11" pad="14"/>
+<connect gate="G$1" pin="*10" pad="13"/>
+<connect gate="G$1" pin="*11" pad="14"/>
+<connect gate="G$1" pin="*3" pad="6"/>
+<connect gate="G$1" pin="*5" pad="8"/>
+<connect gate="G$1" pin="*6" pad="9"/>
+<connect gate="G$1" pin="*9" pad="12"/>
 <connect gate="G$1" pin="12" pad="15"/>
 <connect gate="G$1" pin="13" pad="16"/>
 <connect gate="G$1" pin="2" pad="5"/>
-<connect gate="G$1" pin="3" pad="6"/>
 <connect gate="G$1" pin="4" pad="7"/>
-<connect gate="G$1" pin="5" pad="8"/>
-<connect gate="G$1" pin="6" pad="9"/>
 <connect gate="G$1" pin="7" pad="10"/>
 <connect gate="G$1" pin="8" pad="11"/>
-<connect gate="G$1" pin="9" pad="12"/>
 <connect gate="G$1" pin="A0" pad="17"/>
 <connect gate="G$1" pin="A1" pad="18"/>
 <connect gate="G$1" pin="A2" pad="19"/>
@@ -4158,12 +4158,12 @@ See http://www.sparkfun.com/commerce/product_info.php?products_id=9473 for more 
 <connect gate="G$1" pin="A6" pad="A6"/>
 <connect gate="G$1" pin="A7" pad="A7"/>
 <connect gate="G$1" pin="GND" pad="4"/>
-<connect gate="G$1" pin="GND2" pad="23"/>
+<connect gate="G$1" pin="GND@2" pad="23"/>
 <connect gate="G$1" pin="RAW" pad="24"/>
 <connect gate="G$1" pin="RST" pad="3"/>
-<connect gate="G$1" pin="RST2" pad="22"/>
-<connect gate="G$1" pin="RX1" pad="2"/>
-<connect gate="G$1" pin="TX0" pad="1"/>
+<connect gate="G$1" pin="RST@2" pad="22"/>
+<connect gate="G$1" pin="RXI" pad="2"/>
+<connect gate="G$1" pin="TXO" pad="1"/>
 <connect gate="G$1" pin="VCC" pad="21"/>
 </connects>
 <technologies>
@@ -4184,7 +4184,7 @@ https://www.sparkfun.com/products/8745</description>
 <device name="" package="LOGIC_LEVEL_CONVERTER">
 <connects>
 <connect gate="G$1" pin="GND" pad="P$4"/>
-<connect gate="G$1" pin="GND2" pad="P$9"/>
+<connect gate="G$1" pin="GND@2" pad="P$9"/>
 <connect gate="G$1" pin="HV" pad="P$10"/>
 <connect gate="G$1" pin="HV_RXI_1" pad="P$11"/>
 <connect gate="G$1" pin="HV_RXI_2" pad="P$8"/>
@@ -4255,29 +4255,29 @@ https://www.sparkfun.com/products/8745</description>
 <devices>
 <device name="" package="ARDUINO_PRO_MICRO">
 <connects>
-<connect gate="G$1" pin="10" pad="13"/>
+<connect gate="G$1" pin="*10" pad="13"/>
+<connect gate="G$1" pin="*3" pad="6"/>
+<connect gate="G$1" pin="*5" pad="8"/>
+<connect gate="G$1" pin="*6" pad="9"/>
+<connect gate="G$1" pin="*9" pad="12"/>
 <connect gate="G$1" pin="11(MOSI)" pad="14"/>
 <connect gate="G$1" pin="12(MISO)" pad="15"/>
 <connect gate="G$1" pin="13(SCK)" pad="16"/>
 <connect gate="G$1" pin="2" pad="5"/>
-<connect gate="G$1" pin="3" pad="6"/>
 <connect gate="G$1" pin="4" pad="7"/>
-<connect gate="G$1" pin="5" pad="8"/>
-<connect gate="G$1" pin="6" pad="9"/>
 <connect gate="G$1" pin="7" pad="10"/>
 <connect gate="G$1" pin="8" pad="11"/>
-<connect gate="G$1" pin="9" pad="12"/>
 <connect gate="G$1" pin="A0" pad="17"/>
 <connect gate="G$1" pin="A1" pad="18"/>
 <connect gate="G$1" pin="A2" pad="19"/>
 <connect gate="G$1" pin="A3" pad="20"/>
 <connect gate="G$1" pin="GND" pad="4"/>
-<connect gate="G$1" pin="GND1" pad="3"/>
-<connect gate="G$1" pin="GND2" pad="23"/>
+<connect gate="G$1" pin="GND@1" pad="3"/>
+<connect gate="G$1" pin="GND@2" pad="23"/>
 <connect gate="G$1" pin="RAW" pad="24"/>
 <connect gate="G$1" pin="RESET" pad="22"/>
 <connect gate="G$1" pin="RXI" pad="2"/>
-<connect gate="G$1" pin="TX0" pad="1"/>
+<connect gate="G$1" pin="TXO" pad="1"/>
 <connect gate="G$1" pin="VCC" pad="21"/>
 </connects>
 <technologies>


### PR DESCRIPTION
Hi Folks,
In this pull request I have changed the pin names on the symbols and layouts for Pro Mini, Pro Micro and a couple of others.  These changes are to bring the labeling in line with the boards these components are intended to represent.
Changed occurrences of RX1 to RXI
Changed occurrences of TX0 to TXO
Changed occurrences of GNDn to GND@n
Changed occurrences of RSTn to RST@n
Added "*" to PWM enabled pins on Pro Mini and Pro Micro

If this isn't the sort of edits you are looking for, feel free to say "no thanks".

Thanks,
Chip
