### PR TITLE
Added POWER_JACK_PTH_BREAD for PRT-10811

### DIFF
--- a/SparkFun-Connectors.lbr
+++ b/SparkFun-Connectors.lbr
@@ -17373,6 +17373,24 @@ Matches 4UCONN part # 11026&lt;br&gt;
 <text x="-3.502" y="0.1" size="0.4064" layer="25">&gt;Name</text>
 <text x="-3.502" y="-0.408" size="0.4064" layer="27">&gt;Value</text>
 </package>
+<package name="POWER_JACK_PTH_BREAD">
+<description>&lt;h1&gt;DC Barrel Jack Adapter - Breadboard Compatible&lt;/h1&gt;
+&lt;h2&gt;PRT-10811&lt;/h2&gt;</description>
+<wire x1="4.5" y1="14.6" x2="0.9" y2="14.6" width="0.2032" layer="21"/>
+<wire x1="-4.5" y1="3.6" x2="-4.5" y2="0.1" width="0.2032" layer="51"/>
+<wire x1="4.5" y1="0.1" x2="4.5" y2="3.4" width="0.2032" layer="51"/>
+<wire x1="4.5" y1="0.1" x2="-4.5" y2="0.1" width="0.2032" layer="51"/>
+<wire x1="4.5" y1="3.6" x2="4.5" y2="9.5" width="0.2032" layer="21"/>
+<wire x1="4.5" y1="14.6" x2="4.5" y2="11.9" width="0.2032" layer="21"/>
+<wire x1="-4.5" y1="3.6" x2="-4.5" y2="14.6" width="0.2032" layer="21"/>
+<wire x1="-4.5" y1="14.6" x2="-0.9" y2="14.6" width="0.2032" layer="21"/>
+<wire x1="-4.5" y1="3.6" x2="4.5" y2="3.6" width="0.2032" layer="21"/>
+<pad name="PWR" x="0" y="13.7" drill="1.3"/>
+<pad name="GND" x="0" y="7.9" drill="1.3"/>
+<pad name="GNDBREAK" x="4.8" y="10.7" drill="1.3" rot="R90"/>
+<text x="-3.81" y="5.08" size="0.4064" layer="25">&gt;NAME</text>
+<text x="-3.81" y="4.06" size="0.4064" layer="27">&gt;VALUE</text>
+</package>
 </packages>
 <symbols>
 <symbol name="ARDUINO_SERIAL_PROGRAM">
@@ -25020,8 +25038,6 @@ Miniature 5-pin connection for temporary programming of PICs. Use this device in
 This is the standard 5.5mm barrel jack for power.&lt;br&gt;
 The PTH is the most common, proven, reliable, footprint.&lt;br&gt;
 The Slot footprint only works if the mill layer is transmitted to the PCB fab house so be warned.&lt;br&gt;
-Spark Fun Electronics SKU : PRT-00119&lt;br&gt;
-SMT: CONN-08106&lt;br&gt;
 
 Mating wall wart : TOL-00298 (and others)</description>
 <gates>
@@ -25048,7 +25064,9 @@ Mating wall wart : TOL-00298 (and others)</description>
 <connect gate="G$1" pin="PWR" pad="PWR"/>
 </connects>
 <technologies>
-<technology name=""/>
+<technology name="">
+<attribute name="PROD_ID" value="PRT-00119" constant="no"/>
+</technology>
 </technologies>
 </device>
 <device name="PTH" package="POWER_JACK_PTH">
@@ -25058,7 +25076,9 @@ Mating wall wart : TOL-00298 (and others)</description>
 <connect gate="G$1" pin="PWR" pad="PWR"/>
 </connects>
 <technologies>
-<technology name=""/>
+<technology name="">
+<attribute name="PROD_ID" value="PRT-00119" constant="no"/>
+</technology>
 </technologies>
 </device>
 <device name="COMBO" package="POWER_JACK_COMBO">
@@ -25078,7 +25098,9 @@ Mating wall wart : TOL-00298 (and others)</description>
 <connect gate="G$1" pin="PWR" pad="PWR"/>
 </connects>
 <technologies>
-<technology name=""/>
+<technology name="">
+<attribute name="PROD_ID" value="PRT-00119" constant="no"/>
+</technology>
 </technologies>
 </device>
 <device name="1" package="POWER_JACK_SMD_OVERPASTE_REDBOARD_0603">
@@ -25099,6 +25121,18 @@ Mating wall wart : TOL-00298 (and others)</description>
 </connects>
 <technologies>
 <technology name=""/>
+</technologies>
+</device>
+<device name="PTH_BREAD" package="POWER_JACK_PTH_BREAD">
+<connects>
+<connect gate="G$1" pin="GND" pad="GND"/>
+<connect gate="G$1" pin="GNDBREAK" pad="GNDBREAK"/>
+<connect gate="G$1" pin="PWR" pad="PWR"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="PRT-10811" constant="no"/>
+</technology>
 </technologies>
 </device>
 </devices>


### PR DESCRIPTION
Added the breadboard friendly PRT-10811 package to the POWER_JACK
device.
Moved product SKU info in POWER_JACK description to PROD_ID attributes.
