### PR TITLE
fix reversed USB-PCB GND and 5V lines

### DIFF
--- a/SparkFun-Connectors.lbr
+++ b/SparkFun-Connectors.lbr
@@ -13437,14 +13437,17 @@ This is a footprint for an edge mount RF antenna. Works pretty well with SMA typ
 <hole x="0" y="-2.2" drill="0.9"/>
 </package>
 <package name="USB-A-PCB">
+<description>Card-edge USB A connector.
+
+For boards designed to be plugged directly into a USB slot. If possible, ensure that your PCB is about 2.4mm thick to fit snugly.</description>
 <wire x1="-5" y1="6" x2="3.7" y2="6" width="0.127" layer="51"/>
 <wire x1="3.7" y1="6" x2="3.7" y2="-6" width="0.127" layer="51"/>
 <wire x1="3.7" y1="-6" x2="-5" y2="-6" width="0.127" layer="51"/>
 <wire x1="-5" y1="-6" x2="-5" y2="6" width="0.127" layer="51"/>
-<smd name="5V" x="-0.2" y="-3.5" dx="7.5" dy="1.5" layer="1"/>
+<smd name="GND" x="-0.2" y="-3.5" dx="7.5" dy="1.5" layer="1"/>
 <smd name="USB_M" x="0.3" y="-1" dx="6.5" dy="1" layer="1"/>
 <smd name="USB_P" x="0.3" y="1" dx="6.5" dy="1" layer="1"/>
-<smd name="GND" x="-0.2" y="3.5" dx="7.5" dy="1.5" layer="1"/>
+<smd name="5V" x="-0.2" y="3.5" dx="7.5" dy="1.5" layer="1"/>
 <text x="-1.27" y="5.08" size="0.4064" layer="25">&gt;Name</text>
 <text x="-1.27" y="-5.08" size="0.4064" layer="27">&gt;Value</text>
 </package>


### PR DESCRIPTION
The 5v and ground lines on the PCB edge connector appear to be reversed. Lost a board rev to this. Please review to make sure we've got it right this time. Thanks!
