### PR TITLE
Tighten solder bridge symbol SJ.

### DIFF
--- a/SparkFun-Passives.lbr
+++ b/SparkFun-Passives.lbr
@@ -1777,8 +1777,8 @@ Source: RS Components</description>
 <wire x1="-0.381" y1="-0.635" x2="-0.381" y2="0.635" width="1.27" layer="94" curve="-180" cap="flat"/>
 <wire x1="2.54" y1="0" x2="1.651" y2="0" width="0.1524" layer="94"/>
 <wire x1="-2.54" y1="0" x2="-1.651" y2="0" width="0.1524" layer="94"/>
-<text x="-2.54" y="2.54" size="1.778" layer="95">&gt;NAME</text>
-<text x="-2.54" y="-5.08" size="1.778" layer="96">&gt;VALUE</text>
+<text x="-2.54" y="1.778" size="1.778" layer="95">&gt;NAME</text>
+<text x="-2.54" y="-3.556" size="1.778" layer="96">&gt;VALUE</text>
 <pin name="2" x="5.08" y="0" visible="off" length="short" direction="pas" swaplevel="1" rot="R180"/>
 <pin name="1" x="-5.08" y="0" visible="off" length="short" direction="pas" swaplevel="1"/>
 </symbol>


### PR DESCRIPTION
Moves the >Name and >Value text in the solder bridge symbol SJ, making the symbol visual more appealing (in my opinion) and, perhaps more importantly, to fit into slightly smaller space, allowing tighter placement on a schematic.
