### PR TITLE
Added NPN Transistor and P-MOSFET variants

### DIFF
--- a/SparkFun-DiscreteSemi.lbr
+++ b/SparkFun-DiscreteSemi.lbr
@@ -2527,9 +2527,9 @@ FQP27P06 -
 </device>
 <device name="FQP27P06" package="TO220V">
 <connects>
-<connect gate="G$1" pin="D" pad="3"/>
+<connect gate="G$1" pin="D" pad="2"/>
 <connect gate="G$1" pin="G" pad="1"/>
-<connect gate="G$1" pin="S" pad="2"/>
+<connect gate="G$1" pin="S" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>


### PR DESCRIPTION
I was using the library to design a simple board for a P-Channel MOSFET driver, and when I examined the pinouts for the NPN Transistor and compared them to the datasheet I got from the Sparkfun website, I noticed that the pins were backwards. 

After looking through the three NPN TO-92 Transistors in the Sparkfun website, I found that the pinout from the library matched one of them, but was backwards for the other two.. 
The 2N3904 is opposite from the BC547 and P2N2222A. 

This could cause really confusing problems for people using the
Sparkfun Eagle Library if they happen to get a transistor with the wrong pin
map. (like me)

So, I Added Pin Mapping Variants for:

TRANSISTOR_NPN
- BC547 - COM-08928 (TO-92 45V 100mA) (1.Collector 2.Base 3.Emitter)
- 2N3904 - COM-00521 (TO-92 40V 200mA) (1.Emitter 2.Base 3.Collector)
- P2N2222A - COM-12852 (TO-92 40V 600mA) (1.Collector 2.Base 3.Emitter)

The Library was also missing the TO-220V variant for the P-Channel Mosfet

Added Pin Mapping Variant for:
MOSFET-PCHANNEL
- FQP27P06 - COM-10349 (TO-220 -60V -27A) (1.Gate 2.Source 3.Drain)

Also added comments and links in the descriptions.
