### PR TITLE
Changed pin connections on RGB Rotary Encoder.

### DIFF
--- a/SparkFun-Electromechanical.lbr
+++ b/SparkFun-Electromechanical.lbr
@@ -12562,10 +12562,10 @@ EC12PLRGBSDVBF-D: http://top-up.so-buy.com/front/bin/ptdetail.phtml?Part=EC12PLR
 <devices>
 <device name="" package="ENCODER_LED_3">
 <connects>
-<connect gate="G$1" pin="+" pad="5"/>
-<connect gate="G$1" pin="-B" pad="4"/>
-<connect gate="G$1" pin="-G" pad="2"/>
-<connect gate="G$1" pin="-R" pad="1"/>
+<connect gate="G$1" pin="+" pad="1"/>
+<connect gate="G$1" pin="-B" pad="2"/>
+<connect gate="G$1" pin="-G" pad="4"/>
+<connect gate="G$1" pin="-R" pad="5"/>
 <connect gate="G$1" pin="A" pad="A"/>
 <connect gate="G$1" pin="B" pad="B"/>
 <connect gate="G$1" pin="C" pad="C"/>
@@ -12577,10 +12577,10 @@ EC12PLRGBSDVBF-D: http://top-up.so-buy.com/front/bin/ptdetail.phtml?Part=EC12PLR
 </device>
 <device name="KIT" package="ENCODER_LED_3_KIT">
 <connects>
-<connect gate="G$1" pin="+" pad="5"/>
-<connect gate="G$1" pin="-B" pad="4"/>
-<connect gate="G$1" pin="-G" pad="2"/>
-<connect gate="G$1" pin="-R" pad="1"/>
+<connect gate="G$1" pin="+" pad="1"/>
+<connect gate="G$1" pin="-B" pad="2"/>
+<connect gate="G$1" pin="-G" pad="4"/>
+<connect gate="G$1" pin="-R" pad="5"/>
 <connect gate="G$1" pin="A" pad="A"/>
 <connect gate="G$1" pin="B" pad="B"/>
 <connect gate="G$1" pin="C" pad="C"/>


### PR DESCRIPTION
The pins were reversed (as if looking from wrong side onto schematic).

Found out while debugging the pcb. The leds were behaving oddly :)

Component diagram
http://dlnmh9ip6v2uc.cloudfront.net/datasheets/Components/Switches/EC12PLRGBSDVBF-D-25K-24-24C-6108-6H.pdf

This pinout is also confirmed in first comment(member 333036) on product page:
https://www.sparkfun.com/products/10982

Thanks!
