### PR TITLE
Improved AVR SPI Programmer connector

### DIFF
--- a/SparkFun-Connectors.lbr
+++ b/SparkFun-Connectors.lbr
@@ -21740,25 +21740,25 @@ This is the standard AVR In Circuit Serial Programming header. Minimal, but incl
 </device>
 </devices>
 </deviceset>
-<deviceset name="AVR_SPI_PROG2">
+<deviceset name="AVR_SPI_PROG2" prefix="J">
 <description>&lt;b&gt;AVR 10-pin ICSP Header&lt;/b&gt; 
 This is the standard AVR In Circuit Serial Programming header. Minimal, but includes pin one indicator. Works with standard Olimex programmers. Also look for the 6-pin reduced version. Spark Fun Electronics SKU: PRT-00778</description>
 <gates>
-<gate name="A" symbol="AVR_SPI_PROGRAMMER-1" x="0" y="0"/>
+<gate name="G$1" symbol="AVR_SPI_PROGRAMMER-1" x="0" y="0"/>
 </gates>
 <devices>
 <device name="PTH" package="AVR_ICSP">
 <connects>
-<connect gate="A" pin="GND@1" pad="4"/>
-<connect gate="A" pin="GND@2" pad="6"/>
-<connect gate="A" pin="GND@3" pad="8"/>
-<connect gate="A" pin="GND@4" pad="10"/>
-<connect gate="A" pin="MISO" pad="9"/>
-<connect gate="A" pin="MOSI" pad="1"/>
-<connect gate="A" pin="NC" pad="3"/>
-<connect gate="A" pin="RESET" pad="5"/>
-<connect gate="A" pin="SCK" pad="7"/>
-<connect gate="A" pin="VCC" pad="2"/>
+<connect gate="G$1" pin="GND@1" pad="4"/>
+<connect gate="G$1" pin="GND@2" pad="6"/>
+<connect gate="G$1" pin="GND@3" pad="8"/>
+<connect gate="G$1" pin="GND@4" pad="10"/>
+<connect gate="G$1" pin="MISO" pad="9"/>
+<connect gate="G$1" pin="MOSI" pad="1"/>
+<connect gate="G$1" pin="NC" pad="3"/>
+<connect gate="G$1" pin="RESET" pad="5"/>
+<connect gate="G$1" pin="SCK" pad="7"/>
+<connect gate="G$1" pin="VCC" pad="2"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -21766,16 +21766,16 @@ This is the standard AVR In Circuit Serial Programming header. Minimal, but incl
 </device>
 <device name="PTH2" package="2X5-SHROUDED">
 <connects>
-<connect gate="A" pin="GND@1" pad="4"/>
-<connect gate="A" pin="GND@2" pad="6"/>
-<connect gate="A" pin="GND@3" pad="8"/>
-<connect gate="A" pin="GND@4" pad="10"/>
-<connect gate="A" pin="MISO" pad="9"/>
-<connect gate="A" pin="MOSI" pad="1"/>
-<connect gate="A" pin="NC" pad="3"/>
-<connect gate="A" pin="RESET" pad="5"/>
-<connect gate="A" pin="SCK" pad="7"/>
-<connect gate="A" pin="VCC" pad="2"/>
+<connect gate="G$1" pin="GND@1" pad="4"/>
+<connect gate="G$1" pin="GND@2" pad="6"/>
+<connect gate="G$1" pin="GND@3" pad="8"/>
+<connect gate="G$1" pin="GND@4" pad="10"/>
+<connect gate="G$1" pin="MISO" pad="9"/>
+<connect gate="G$1" pin="MOSI" pad="1"/>
+<connect gate="G$1" pin="NC" pad="3"/>
+<connect gate="G$1" pin="RESET" pad="5"/>
+<connect gate="G$1" pin="SCK" pad="7"/>
+<connect gate="G$1" pin="VCC" pad="2"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -21783,16 +21783,16 @@ This is the standard AVR In Circuit Serial Programming header. Minimal, but incl
 </device>
 <device name="LOCK" package="2X5-SHROUDED_LOCK">
 <connects>
-<connect gate="A" pin="GND@1" pad="4"/>
-<connect gate="A" pin="GND@2" pad="6"/>
-<connect gate="A" pin="GND@3" pad="8"/>
-<connect gate="A" pin="GND@4" pad="10"/>
-<connect gate="A" pin="MISO" pad="9"/>
-<connect gate="A" pin="MOSI" pad="1"/>
-<connect gate="A" pin="NC" pad="3"/>
-<connect gate="A" pin="RESET" pad="5"/>
-<connect gate="A" pin="SCK" pad="7"/>
-<connect gate="A" pin="VCC" pad="2"/>
+<connect gate="G$1" pin="GND@1" pad="4"/>
+<connect gate="G$1" pin="GND@2" pad="6"/>
+<connect gate="G$1" pin="GND@3" pad="8"/>
+<connect gate="G$1" pin="GND@4" pad="10"/>
+<connect gate="G$1" pin="MISO" pad="9"/>
+<connect gate="G$1" pin="MOSI" pad="1"/>
+<connect gate="G$1" pin="NC" pad="3"/>
+<connect gate="G$1" pin="RESET" pad="5"/>
+<connect gate="G$1" pin="SCK" pad="7"/>
+<connect gate="G$1" pin="VCC" pad="2"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -21800,16 +21800,16 @@ This is the standard AVR In Circuit Serial Programming header. Minimal, but incl
 </device>
 <device name="SMD" package="2X5-SHROUDED_SMD">
 <connects>
-<connect gate="A" pin="GND@1" pad="4"/>
-<connect gate="A" pin="GND@2" pad="6"/>
-<connect gate="A" pin="GND@3" pad="8"/>
-<connect gate="A" pin="GND@4" pad="10"/>
-<connect gate="A" pin="MISO" pad="9"/>
-<connect gate="A" pin="MOSI" pad="1"/>
-<connect gate="A" pin="NC" pad="3"/>
-<connect gate="A" pin="RESET" pad="5"/>
-<connect gate="A" pin="SCK" pad="7"/>
-<connect gate="A" pin="VCC" pad="2"/>
+<connect gate="G$1" pin="GND@1" pad="4"/>
+<connect gate="G$1" pin="GND@2" pad="6"/>
+<connect gate="G$1" pin="GND@3" pad="8"/>
+<connect gate="G$1" pin="GND@4" pad="10"/>
+<connect gate="G$1" pin="MISO" pad="9"/>
+<connect gate="G$1" pin="MOSI" pad="1"/>
+<connect gate="G$1" pin="NC" pad="3"/>
+<connect gate="G$1" pin="RESET" pad="5"/>
+<connect gate="G$1" pin="SCK" pad="7"/>
+<connect gate="G$1" pin="VCC" pad="2"/>
 </connects>
 <technologies>
 <technology name=""/>


### PR DESCRIPTION
I've applied this changes to the `AVR_SPI_PROGRAMMER-1` symbol:
- Renamed pin "5" -> "VCC" (because can be used with different voltages than +5V, for example +3.3V);
- Set pin name to the same values as the cosmetics texts;
- Set pin directions;

I've also edited the `AVR_SPI_PROG2` device to:
- Set the name to the generic "G$1" instead of "A";
- Added the prefix "J".

Congratulations for this great library. I will be happy to help improving it.
