### PR TITLE
Connectors: fix USB-A-H D+/D- connections

### DIFF
--- a/SparkFun-Connectors.lbr
+++ b/SparkFun-Connectors.lbr
@@ -27132,8 +27132,8 @@ Power pads are designated by the star cutout in the top layer.</description>
 <devices>
 <device name="-A-H" package="USB-A-H">
 <connects>
-<connect gate="G$1" pin="D+" pad="D-"/>
-<connect gate="G$1" pin="D-" pad="D+"/>
+<connect gate="G$1" pin="D+" pad="D+"/>
+<connect gate="G$1" pin="D-" pad="D-"/>
 <connect gate="G$1" pin="GND" pad="VBUS"/>
 <connect gate="G$1" pin="VBUS" pad="GND"/>
 </connects>


### PR DESCRIPTION
Does what it says on the tin... the other USB connectors don't seem to have this swap, so I can only assume it is a typo.
