### PR TITLE
update labels on Atmega32u4, remove paste layer for card edge USB connector

### DIFF
--- a/SparkFun-Connectors.lbr
+++ b/SparkFun-Connectors.lbr
@@ -13452,10 +13452,10 @@ For boards designed to be plugged directly into a USB slot. If possible, ensure 
 <wire x1="3.7" y1="6" x2="3.7" y2="-6" width="0.127" layer="51" style="shortdash"/>
 <wire x1="3.7" y1="-6" x2="-5" y2="-6" width="0.127" layer="51"/>
 <wire x1="-5" y1="-6" x2="-5" y2="6" width="0.127" layer="51"/>
-<smd name="5V" x="-0.2" y="-3.5" dx="7.5" dy="1.5" layer="1"/>
-<smd name="USB_M" x="0.3" y="-1" dx="6.5" dy="1" layer="1"/>
-<smd name="USB_P" x="0.3" y="1" dx="6.5" dy="1" layer="1"/>
-<smd name="GND" x="-0.2" y="3.5" dx="7.5" dy="1.5" layer="1"/>
+<smd name="5V" x="-0.2" y="-3.5" dx="7.5" dy="1.5" layer="1" cream="no"/>
+<smd name="USB_M" x="0.3" y="-1" dx="6.5" dy="1" layer="1" cream="no"/>
+<smd name="USB_P" x="0.3" y="1" dx="6.5" dy="1" layer="1" cream="no"/>
+<smd name="GND" x="-0.2" y="3.5" dx="7.5" dy="1.5" layer="1" cream="no"/>
 <text x="-1.27" y="5.08" size="0.4064" layer="25">&gt;Name</text>
 <text x="-1.27" y="-5.08" size="0.4064" layer="27">&gt;Value</text>
 <text x="-6.35" y="-3.81" size="1.016" layer="48" rot="R90">Card edge</text>

--- a/SparkFun-DigitalIC.lbr
+++ b/SparkFun-DigitalIC.lbr
@@ -10006,8 +10006,8 @@ Source: http://www.linear.com .. LT1996</description>
 <text x="30.48" y="-26.162" size="1.524" layer="103">D15</text>
 <text x="30.48" y="-28.702" size="1.524" layer="103">D16</text>
 <text x="30.48" y="-31.242" size="1.524" layer="103">D17</text>
-<text x="30.48" y="-8.382" size="1.524" layer="103">D8</text>
-<text x="30.48" y="-10.922" size="1.524" layer="103">D9#/A8</text>
+<text x="30.48" y="-8.382" size="1.524" layer="103">D8/A8</text>
+<text x="30.48" y="-10.922" size="1.524" layer="103">D9#/A9</text>
 <text x="30.48" y="-13.462" size="1.524" layer="103">D10#</text>
 <text x="30.48" y="-16.002" size="1.524" layer="103">D11#</text>
 <text x="30.48" y="-0.762" size="1.524" layer="103">D5#</text>
@@ -14576,8 +14576,8 @@ Source: http://www.linear.com .. LT1996</description>
 <text x="30.48" y="-26.162" size="1.524" layer="103">D15</text>
 <text x="30.48" y="-28.702" size="1.524" layer="103">D16</text>
 <text x="30.48" y="-31.242" size="1.524" layer="103">D14</text>
-<text x="30.48" y="-8.382" size="1.524" layer="103">D8</text>
-<text x="30.48" y="-10.922" size="1.524" layer="103">D9#/A8</text>
+<text x="30.48" y="-8.382" size="1.524" layer="103">D8/A8</text>
+<text x="30.48" y="-10.922" size="1.524" layer="103">D9#/A9</text>
 <text x="30.48" y="-13.462" size="1.524" layer="103">D10#</text>
 <text x="30.48" y="-16.002" size="1.524" layer="103">D11#</text>
 <text x="30.48" y="-0.762" size="1.524" layer="103">D5#</text>

--- a/SparkFun-DigitalIC.lbr
+++ b/SparkFun-DigitalIC.lbr
@@ -10002,10 +10002,10 @@ Source: http://www.linear.com .. LT1996</description>
 <wire x1="15.24" y1="38.1" x2="-15.24" y2="38.1" width="0.254" layer="94"/>
 <text x="-15.24" y="38.1" size="1.778" layer="95">&gt;NAME</text>
 <text x="-15.24" y="-43.18" size="1.778" layer="96">&gt;VALUE</text>
-<text x="30.48" y="-23.622" size="1.524" layer="103">D14/RX LED</text>
+<text x="30.48" y="-23.622" size="1.524" layer="103">D17/RX LED</text>
 <text x="30.48" y="-26.162" size="1.524" layer="103">D15</text>
 <text x="30.48" y="-28.702" size="1.524" layer="103">D16</text>
-<text x="30.48" y="-31.242" size="1.524" layer="103">D17</text>
+<text x="30.48" y="-31.242" size="1.524" layer="103">D14</text>
 <text x="30.48" y="-8.382" size="1.524" layer="103">D8/A8</text>
 <text x="30.48" y="-10.922" size="1.524" layer="103">D9#/A9</text>
 <text x="30.48" y="-13.462" size="1.524" layer="103">D10#</text>


### PR DESCRIPTION
A8 was mislabeled as being on the same pin as D9
