### PR TITLE
Removed tStop rectangle over part. It prevented solder mask around the p...

### DIFF
--- a/SparkFun-FreqCtrl.lbr
+++ b/SparkFun-FreqCtrl.lbr
@@ -6,7 +6,7 @@
 <setting alwaysvectorfont="no"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.01" altunitdist="inch" altunit="inch"/>
+<grid distance="0.05" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.025" altunitdist="inch" altunit="inch"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="2" name="Route2" color="1" fill="3" visible="yes" active="yes"/>
@@ -913,7 +913,6 @@ This is the "EZ" version, which has limited top masking for improved ease of ass
 <rectangle x1="0.98801875" y1="0.582625" x2="1.40305" y2="0.60446875" layer="200"/>
 <rectangle x1="1.62149375" y1="0.582625" x2="1.6433375" y2="0.60446875" layer="200"/>
 <rectangle x1="-1.6332625" y1="0.60446875" x2="1.6433375" y2="0.6263125" layer="200"/>
-<rectangle x1="-1.75005625" y1="-0.769615625" x2="1.74498125" y2="0.764540625" layer="29"/>
 <wire x1="-1.2" y1="0" x2="-1.2" y2="1.016" width="0.254" layer="1"/>
 <wire x1="-1.2" y1="-1.016" x2="-1.2" y2="0" width="0.254" layer="1"/>
 <wire x1="1.2" y1="0" x2="1.2" y2="1.016" width="0.254" layer="1"/>


### PR DESCRIPTION
tStop rectangle prevent solder mask and may cause exposure of copper plane.
Situation described here with picture of PCB etched with part http://www.element14.com/community/groups/open-source-hardware/blog/2015/03/15/new-parts-new-part-pcb-problem