### PR TITLE
V_REG_LD1117VXX pins incorrectly connected

### DIFF
--- a/SparkFun-PowerIC.lbr
+++ b/SparkFun-PowerIC.lbr
@@ -18231,9 +18231,9 @@ The LD1085xx is a low drop voltage regulator able to provide up to 3 A of output
 <devices>
 <device name="" package="78XXL">
 <connects>
-<connect gate="G$1" pin="GND" pad="IN"/>
-<connect gate="G$1" pin="IN" pad="OUT"/>
-<connect gate="G$1" pin="OUT" pad="GND"/>
+<connect gate="G$1" pin="GND" pad="GND"/>
+<connect gate="G$1" pin="IN" pad="IN"/>
+<connect gate="G$1" pin="OUT" pad="OUT"/>
 </connects>
 <technologies>
 <technology name=""/>


### PR DESCRIPTION
Library: SparkFun-PowerIC.lbr
Device: V_REG_LD1117VXX
Package: 78XXL

Issue:
G$1.GND is connected to IN
G$1.IN is connected to OUT
G$1.OUT is connected to GND

Fix:
GND should be connected to GND, IN to IN and OUT to OUT.
