### PR TITLE
Added ESP8266_THING and ESP8266_THING_DEV footprints

### DIFF
--- a/SparkFun-Boards.lbr
+++ b/SparkFun-Boards.lbr
@@ -6,11 +6,7 @@
 <setting alwaysvectorfont="no"/>
 <setting verticaltext="up"/>
 </settings>
-<<<<<<< HEAD
-<grid distance="0.5" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.025" altunitdist="inch" altunit="inch"/>
-=======
-<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="no" altdistance="0.01" altunitdist="inch" altunit="inch"/>
->>>>>>> 23c62c9d87830f32101de7b80121a1f37d166481
+<grid distance="0.05" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.025" altunitdist="inch" altunit="inch"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="2" name="Route2" color="1" fill="3" visible="no" active="no"/>

--- a/SparkFun-Boards.lbr
+++ b/SparkFun-Boards.lbr
@@ -6,7 +6,7 @@
 <setting alwaysvectorfont="no"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.05" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.025" altunitdist="inch" altunit="inch"/>
+<grid distance="0.5" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.025" altunitdist="inch" altunit="inch"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="2" name="Route2" color="1" fill="3" visible="no" active="no"/>
@@ -7658,6 +7658,83 @@ Footprint designed for Sullins SBH11-NBPC-D20-SM-BK</description>
 <pad name="MOSI" x="25.4500125" y="57.29000625" drill="1.016" diameter="1.8796" rot="R90"/>
 <pad name="GND_ICSP" x="27.9900125" y="57.29000625" drill="1.016" diameter="1.8796" rot="R90"/>
 </package>
+<package name="ESP8266_THING">
+<wire x1="-12.827" y1="27.94" x2="-12.827" y2="-19.685" width="0.127" layer="51"/>
+<wire x1="-12.827" y1="-19.685" x2="-12.827" y2="-27.305" width="0.127" layer="51"/>
+<wire x1="-12.827" y1="-27.305" x2="12.827" y2="-27.305" width="0.127" layer="51"/>
+<wire x1="12.827" y1="-27.305" x2="12.827" y2="-19.685" width="0.127" layer="51"/>
+<wire x1="12.827" y1="-19.685" x2="12.827" y2="27.94" width="0.127" layer="51"/>
+<wire x1="12.827" y1="27.94" x2="6.858" y2="27.94" width="0.127" layer="51"/>
+<pad name="1" x="-11.43" y="11.43" drill="1.016" diameter="1.8796"/>
+<pad name="2" x="-11.43" y="8.89" drill="1.016" diameter="1.8796"/>
+<pad name="3" x="-11.43" y="6.35" drill="1.016" diameter="1.8796"/>
+<pad name="4" x="-11.43" y="3.81" drill="1.016" diameter="1.8796"/>
+<pad name="5" x="-11.43" y="1.27" drill="1.016" diameter="1.8796"/>
+<pad name="6" x="-11.43" y="-1.27" drill="1.016" diameter="1.8796"/>
+<pad name="7" x="-11.43" y="-3.81" drill="1.016" diameter="1.8796"/>
+<pad name="8" x="-11.43" y="-6.35" drill="1.016" diameter="1.8796"/>
+<pad name="9" x="-11.43" y="-8.89" drill="1.016" diameter="1.8796"/>
+<pad name="10" x="-11.43" y="-11.43" drill="1.016" diameter="1.8796"/>
+<pad name="11" x="11.43" y="-11.43" drill="1.016" diameter="1.8796"/>
+<pad name="12" x="11.43" y="-8.89" drill="1.016" diameter="1.8796"/>
+<pad name="13" x="11.43" y="-6.35" drill="1.016" diameter="1.8796"/>
+<pad name="14" x="11.43" y="-3.81" drill="1.016" diameter="1.8796"/>
+<pad name="15" x="11.43" y="-1.27" drill="1.016" diameter="1.8796"/>
+<pad name="16" x="11.43" y="1.27" drill="1.016" diameter="1.8796"/>
+<pad name="17" x="11.43" y="3.81" drill="1.016" diameter="1.8796"/>
+<pad name="18" x="11.43" y="6.35" drill="1.016" diameter="1.8796"/>
+<pad name="19" x="11.43" y="8.89" drill="1.016" diameter="1.8796"/>
+<pad name="20" x="11.43" y="11.43" drill="1.016" diameter="1.8796"/>
+<text x="-3.81" y="-24.13" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.81" y="-26.035" size="1.27" layer="27">&gt;VALUE</text>
+<wire x1="6.858" y1="27.94" x2="1.016" y2="27.94" width="0.127" layer="51"/>
+<wire x1="1.016" y1="27.94" x2="-1.27" y2="27.94" width="0.127" layer="51"/>
+<wire x1="-1.27" y1="27.94" x2="-12.827" y2="27.94" width="0.127" layer="51"/>
+<wire x1="-8.89" y1="27.94" x2="-8.89" y2="29.21" width="0.127" layer="51"/>
+<wire x1="-8.89" y1="29.21" x2="-1.27" y2="29.21" width="0.127" layer="51"/>
+<wire x1="-1.27" y1="29.21" x2="-1.27" y2="27.94" width="0.127" layer="51"/>
+<wire x1="12.827" y1="-19.685" x2="-12.827" y2="-19.685" width="0.127" layer="51"/>
+<wire x1="6.858" y1="27.94" x2="6.858" y2="28.194" width="0.127" layer="51"/>
+<wire x1="6.858" y1="28.194" x2="1.016" y2="28.194" width="0.127" layer="51"/>
+<wire x1="1.016" y1="28.194" x2="1.016" y2="27.94" width="0.127" layer="51"/>
+</package>
+<package name="ESP8266_THING_DEV">
+<wire x1="-12.827" y1="27.94" x2="-12.827" y2="-19.685" width="0.127" layer="51"/>
+<wire x1="-12.827" y1="-19.685" x2="-12.827" y2="-27.305" width="0.127" layer="51"/>
+<wire x1="-12.827" y1="-27.305" x2="12.827" y2="-27.305" width="0.127" layer="51"/>
+<wire x1="12.827" y1="-27.305" x2="12.827" y2="-19.685" width="0.127" layer="51"/>
+<wire x1="12.827" y1="-19.685" x2="12.827" y2="27.94" width="0.127" layer="51"/>
+<wire x1="12.827" y1="27.94" x2="6.858" y2="27.94" width="0.127" layer="51"/>
+<pad name="1" x="-11.43" y="11.43" drill="1.016" diameter="1.8796"/>
+<pad name="2" x="-11.43" y="8.89" drill="1.016" diameter="1.8796"/>
+<pad name="3" x="-11.43" y="6.35" drill="1.016" diameter="1.8796"/>
+<pad name="4" x="-11.43" y="3.81" drill="1.016" diameter="1.8796"/>
+<pad name="5" x="-11.43" y="1.27" drill="1.016" diameter="1.8796"/>
+<pad name="6" x="-11.43" y="-1.27" drill="1.016" diameter="1.8796"/>
+<pad name="7" x="-11.43" y="-3.81" drill="1.016" diameter="1.8796"/>
+<pad name="8" x="-11.43" y="-6.35" drill="1.016" diameter="1.8796"/>
+<pad name="9" x="-11.43" y="-8.89" drill="1.016" diameter="1.8796"/>
+<pad name="10" x="-11.43" y="-11.43" drill="1.016" diameter="1.8796"/>
+<pad name="11" x="11.43" y="-11.43" drill="1.016" diameter="1.8796"/>
+<pad name="12" x="11.43" y="-8.89" drill="1.016" diameter="1.8796"/>
+<pad name="13" x="11.43" y="-6.35" drill="1.016" diameter="1.8796"/>
+<pad name="14" x="11.43" y="-3.81" drill="1.016" diameter="1.8796"/>
+<pad name="15" x="11.43" y="-1.27" drill="1.016" diameter="1.8796"/>
+<pad name="16" x="11.43" y="1.27" drill="1.016" diameter="1.8796"/>
+<pad name="17" x="11.43" y="3.81" drill="1.016" diameter="1.8796"/>
+<pad name="18" x="11.43" y="6.35" drill="1.016" diameter="1.8796"/>
+<pad name="19" x="11.43" y="8.89" drill="1.016" diameter="1.8796"/>
+<pad name="20" x="11.43" y="11.43" drill="1.016" diameter="1.8796"/>
+<text x="-3.81" y="-24.13" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.81" y="-26.035" size="1.27" layer="27">&gt;VALUE</text>
+<wire x1="6.858" y1="27.94" x2="1.016" y2="27.94" width="0.127" layer="51"/>
+<wire x1="1.016" y1="27.94" x2="-1.27" y2="27.94" width="0.127" layer="51"/>
+<wire x1="-1.27" y1="27.94" x2="-12.827" y2="27.94" width="0.127" layer="51"/>
+<wire x1="-8.89" y1="27.94" x2="-8.89" y2="29.21" width="0.127" layer="51"/>
+<wire x1="-8.89" y1="29.21" x2="-1.27" y2="29.21" width="0.127" layer="51"/>
+<wire x1="-1.27" y1="29.21" x2="-1.27" y2="27.94" width="0.127" layer="51"/>
+<wire x1="12.827" y1="-19.685" x2="-12.827" y2="-19.685" width="0.127" layer="51"/>
+</package>
 </packages>
 <symbols>
 <symbol name="ARDUINO-MEGA">
@@ -8926,6 +9003,62 @@ Breakout</text>
 <pin name="MOSI" x="-12.7" y="-20.32" visible="pin" length="short"/>
 <pin name="!RST!@ICSP" x="-12.7" y="-22.86" visible="pin" length="short"/>
 <pin name="GND@ICSP" x="-12.7" y="-25.4" visible="pin" length="short"/>
+</symbol>
+<symbol name="ESP8266_THING">
+<wire x1="-7.62" y1="15.24" x2="-7.62" y2="-12.7" width="0.254" layer="94"/>
+<wire x1="-7.62" y1="-12.7" x2="10.16" y2="-12.7" width="0.254" layer="94"/>
+<wire x1="10.16" y1="-12.7" x2="10.16" y2="15.24" width="0.254" layer="94"/>
+<wire x1="10.16" y1="15.24" x2="-7.62" y2="15.24" width="0.254" layer="94"/>
+<text x="-7.62" y="16.002" size="1.778" layer="95">&gt;NAME</text>
+<text x="-7.62" y="-15.24" size="1.778" layer="96">&gt;VALUE</text>
+<pin name="DTR" x="-10.16" y="2.54" length="short"/>
+<pin name="TXO" x="-10.16" y="0" length="short"/>
+<pin name="RXI" x="-10.16" y="-2.54" length="short"/>
+<pin name="VCC@2" x="-10.16" y="-5.08" length="short"/>
+<pin name="NC" x="-10.16" y="-7.62" length="short"/>
+<pin name="GND@2" x="-10.16" y="-10.16" length="short"/>
+<pin name="EN" x="12.7" y="-10.16" length="short" rot="R180"/>
+<pin name="ADC" x="12.7" y="-7.62" length="short" rot="R180"/>
+<pin name="XPD" x="12.7" y="-5.08" length="short" rot="R180"/>
+<pin name="12" x="12.7" y="-2.54" length="short" rot="R180"/>
+<pin name="13" x="12.7" y="0" length="short" rot="R180"/>
+<pin name="4" x="12.7" y="2.54" length="short" rot="R180"/>
+<pin name="SCL" x="-10.16" y="5.08" length="short"/>
+<pin name="VIN" x="12.7" y="10.16" length="short" rot="R180"/>
+<pin name="GND@3" x="12.7" y="12.7" length="short" rot="R180"/>
+<pin name="SDA" x="-10.16" y="7.62" length="short"/>
+<pin name="5" x="12.7" y="7.62" length="short" rot="R180"/>
+<pin name="VCC" x="-10.16" y="10.16" length="short"/>
+<pin name="GND" x="-10.16" y="12.7" length="short"/>
+<pin name="0" x="12.7" y="5.08" length="short" rot="R180"/>
+</symbol>
+<symbol name="ESP8266_THING_DEV">
+<wire x1="-7.62" y1="15.24" x2="-7.62" y2="-12.7" width="0.254" layer="94"/>
+<wire x1="-7.62" y1="-12.7" x2="10.16" y2="-12.7" width="0.254" layer="94"/>
+<wire x1="10.16" y1="-12.7" x2="10.16" y2="15.24" width="0.254" layer="94"/>
+<wire x1="10.16" y1="15.24" x2="-7.62" y2="15.24" width="0.254" layer="94"/>
+<text x="-7.62" y="16.002" size="1.778" layer="95">&gt;NAME</text>
+<text x="-7.62" y="-15.24" size="1.778" layer="96">&gt;VALUE</text>
+<pin name="RST" x="-10.16" y="2.54" length="short"/>
+<pin name="TX" x="-10.16" y="0" length="short"/>
+<pin name="RX" x="-10.16" y="-2.54" length="short"/>
+<pin name="5V" x="-10.16" y="-5.08" length="short"/>
+<pin name="NC" x="-10.16" y="-7.62" length="short"/>
+<pin name="GND@2" x="-10.16" y="-10.16" length="short"/>
+<pin name="15" x="12.7" y="-10.16" length="short" rot="R180"/>
+<pin name="ADC" x="12.7" y="-7.62" length="short" rot="R180"/>
+<pin name="16" x="12.7" y="-5.08" length="short" rot="R180"/>
+<pin name="12" x="12.7" y="-2.54" length="short" rot="R180"/>
+<pin name="13" x="12.7" y="0" length="short" rot="R180"/>
+<pin name="4" x="12.7" y="2.54" length="short" rot="R180"/>
+<pin name="14" x="-10.16" y="5.08" length="short"/>
+<pin name="VIN" x="12.7" y="10.16" length="short" rot="R180"/>
+<pin name="GND@3" x="12.7" y="12.7" length="short" rot="R180"/>
+<pin name="2" x="-10.16" y="7.62" length="short"/>
+<pin name="5" x="12.7" y="7.62" length="short" rot="R180"/>
+<pin name="VCC" x="-10.16" y="10.16" length="short"/>
+<pin name="GND" x="-10.16" y="12.7" length="short"/>
+<pin name="0" x="12.7" y="5.08" length="short" rot="R180"/>
 </symbol>
 </symbols>
 <devicesets>
@@ -11785,6 +11918,76 @@ If you're placing one on the bottom of a board, take care to mind the pin-1 orie
 <connect gate="G$1" pin="SDA" pad="SDA"/>
 <connect gate="G$1" pin="TX" pad="TX"/>
 <connect gate="G$1" pin="VIN" pad="VIN"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="ESP8266_THING" prefix="U">
+<description>ESP8266 Thing footprint</description>
+<gates>
+<gate name="G$1" symbol="ESP8266_THING" x="0" y="0"/>
+</gates>
+<devices>
+<device name="ESP8266_THING" package="ESP8266_THING">
+<connects>
+<connect gate="G$1" pin="0" pad="17"/>
+<connect gate="G$1" pin="12" pad="14"/>
+<connect gate="G$1" pin="13" pad="15"/>
+<connect gate="G$1" pin="4" pad="16"/>
+<connect gate="G$1" pin="5" pad="18"/>
+<connect gate="G$1" pin="ADC" pad="12"/>
+<connect gate="G$1" pin="DTR" pad="5"/>
+<connect gate="G$1" pin="EN" pad="11"/>
+<connect gate="G$1" pin="GND" pad="1"/>
+<connect gate="G$1" pin="GND@2" pad="10"/>
+<connect gate="G$1" pin="GND@3" pad="20"/>
+<connect gate="G$1" pin="NC" pad="9"/>
+<connect gate="G$1" pin="RXI" pad="7"/>
+<connect gate="G$1" pin="SCL" pad="4"/>
+<connect gate="G$1" pin="SDA" pad="3"/>
+<connect gate="G$1" pin="TXO" pad="6"/>
+<connect gate="G$1" pin="VCC" pad="2"/>
+<connect gate="G$1" pin="VCC@2" pad="8"/>
+<connect gate="G$1" pin="VIN" pad="19"/>
+<connect gate="G$1" pin="XPD" pad="13"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="ESP8266_THING_DEV" prefix="U">
+<description>ESP8266 Thing Development Board footprint</description>
+<gates>
+<gate name="G$1" symbol="ESP8266_THING_DEV" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="ESP8266_THING_DEV">
+<connects>
+<connect gate="G$1" pin="0" pad="17"/>
+<connect gate="G$1" pin="12" pad="14"/>
+<connect gate="G$1" pin="13" pad="15"/>
+<connect gate="G$1" pin="14" pad="4"/>
+<connect gate="G$1" pin="15" pad="11"/>
+<connect gate="G$1" pin="16" pad="13"/>
+<connect gate="G$1" pin="2" pad="3"/>
+<connect gate="G$1" pin="4" pad="16"/>
+<connect gate="G$1" pin="5" pad="18"/>
+<connect gate="G$1" pin="5V" pad="19"/>
+<connect gate="G$1" pin="ADC" pad="12"/>
+<connect gate="G$1" pin="GND" pad="1"/>
+<connect gate="G$1" pin="GND@2" pad="10"/>
+<connect gate="G$1" pin="GND@3" pad="20"/>
+<connect gate="G$1" pin="NC" pad="9"/>
+<connect gate="G$1" pin="RST" pad="5"/>
+<connect gate="G$1" pin="RX" pad="7"/>
+<connect gate="G$1" pin="TX" pad="6"/>
+<connect gate="G$1" pin="VCC" pad="2"/>
+<connect gate="G$1" pin="VIN" pad="8"/>
 </connects>
 <technologies>
 <technology name=""/>


### PR DESCRIPTION
Updated the SpartFun-Boards.lbr to add the footprints for ESP8266 breakout and development boards sold by SparkFun.

This includes symbols, packages, and devices for those wanting to incorporate the breakout/development boards directly into other projects. 

I've tried to be as consistent as possible to other SparkFun device footprints in the library.

NOTE: The general order of the pins on the ESP8266_Thing schematics differ from the order within board (e.g. TX, RX pin order).  I've aligned the above updates to be consistent with information defined on the board to avoid potential confusion.  The ESP8266_Thing_Dev schematics and boards lined up perfectly.

Thanks for your consideration,

Jim