### PR TITLE
DIP6 package has been added to MOC3063 device

### DIFF
--- a/SparkFun-DiscreteSemi.lbr
+++ b/SparkFun-DiscreteSemi.lbr
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="7.5.0">
+<eagle version="7.2.0">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
@@ -2851,6 +2851,17 @@ SMD: MOC3063S</description>
 <technology name="">
 <attribute name="PROD_ID" value="IC-10683" constant="no"/>
 </technology>
+</technologies>
+</device>
+<device name="M" package="DIL06">
+<connects>
+<connect gate="G$1" pin="A" pad="1"/>
+<connect gate="G$1" pin="K" pad="2"/>
+<connect gate="G$1" pin="T1" pad="4"/>
+<connect gate="G$1" pin="T2" pad="6"/>
+</connects>
+<technologies>
+<technology name=""/>
 </technologies>
 </device>
 </devices>


### PR DESCRIPTION
hello,

I have made a small changes in the "SparkFun-DiscreteSemi.lbr", where I added DIP6 package to the MOC3063 device.

Please approve this changes if you are agree with this.

br,
/Robi
