### PR TITLE
Fixed Atmega168 unconnected ground pad

### DIFF
--- a/SparkFun-DigitalIC.lbr
+++ b/SparkFun-DigitalIC.lbr
@@ -312,6 +312,7 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <rectangle x1="-1.4286" y1="3.556" x2="-0.9714" y2="4.5466" layer="51"/>
 <rectangle x1="-2.2286" y1="3.556" x2="-1.7714" y2="4.5466" layer="51"/>
 <rectangle x1="-3.0286" y1="3.556" x2="-2.5714" y2="4.5466" layer="51"/>
+<smd name="GND" x="0" y="0" dx="1.27" dy="0.635" layer="1"/>
 </package>
 <package name="QFN-44">
 <wire x1="1.65" y1="-3.5" x2="3.5" y2="-3.5" width="0.2032" layer="21"/>
@@ -670,6 +671,7 @@ You are welcome to use this library for commercial purposes. For attribution, we
 <rectangle x1="-0.9" y1="2.05" x2="-0.6" y2="2.5" layer="51"/>
 <rectangle x1="-1.4" y1="2.05" x2="-1.1" y2="2.5" layer="51"/>
 <rectangle x1="-1.9" y1="2.05" x2="-1.6" y2="2.5" layer="51"/>
+<smd name="GND" x="0" y="0" dx="1.27" dy="0.635" layer="1"/>
 </package>
 <package name="TQFP100">
 <description>&lt;b&gt;100-lead Thin Quad Flat Pack Package Outline&lt;/b&gt;</description>
@@ -18282,6 +18284,7 @@ RTC_GPIO3</text>
 <connect gate="G$1" pin="AVCC" pad="18"/>
 <connect gate="G$1" pin="GND@3" pad="3"/>
 <connect gate="G$1" pin="GND@5" pad="5"/>
+<connect gate="G$1" pin="GND@PAD" pad="GND"/>
 <connect gate="G$1" pin="PB0(ICP)" pad="12"/>
 <connect gate="G$1" pin="PB1(OC1A)" pad="13"/>
 <connect gate="G$1" pin="PB2(SS/OC1B)" pad="14"/>
@@ -18321,6 +18324,7 @@ RTC_GPIO3</text>
 <connect gate="G$1" pin="AVCC" pad="18"/>
 <connect gate="G$1" pin="GND@3" pad="3"/>
 <connect gate="G$1" pin="GND@5" pad="21"/>
+<connect gate="G$1" pin="GND@PAD" pad="GND"/>
 <connect gate="G$1" pin="PB0(ICP)" pad="12"/>
 <connect gate="G$1" pin="PB1(OC1A)" pad="13"/>
 <connect gate="G$1" pin="PB2(SS/OC1B)" pad="14"/>


### PR DESCRIPTION
My eagle complained about a non connected pin so I fixed it in the same way the Atmega328 was fixed with a center (ground) pad connected to the ground pin.
