### PR TITLE
Corrected PIN assignments for Pro Micro

### DIFF
--- a/SparkFun-Boards.lbr
+++ b/SparkFun-Boards.lbr
@@ -6,7 +6,7 @@
 <setting alwaysvectorfont="no"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.05" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.025" altunitdist="inch" altunit="inch"/>
+<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.01" altunitdist="inch" altunit="inch"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="2" name="Route2" color="1" fill="3" visible="no" active="no"/>
@@ -5709,9 +5709,9 @@ There is no on-board regulation. All pins of the W5100 are broken out to two pai
 <pin name="8" x="-10.16" y="-10.16" length="short"/>
 <pin name="*9" x="-10.16" y="-12.7" length="short"/>
 <pin name="*10" x="12.7" y="-12.7" length="short" rot="R180"/>
-<pin name="11(MOSI)" x="12.7" y="-10.16" length="short" rot="R180"/>
-<pin name="12(MISO)" x="12.7" y="-7.62" length="short" rot="R180"/>
-<pin name="13(SCK)" x="12.7" y="-5.08" length="short" rot="R180"/>
+<pin name="16(MOSI)" x="12.7" y="-10.16" length="short" rot="R180"/>
+<pin name="14(MISO)" x="12.7" y="-7.62" length="short" rot="R180"/>
+<pin name="15(SCK)" x="12.7" y="-5.08" length="short" rot="R180"/>
 <pin name="A0" x="12.7" y="-2.54" length="short" rot="R180"/>
 <pin name="A1" x="12.7" y="0" length="short" rot="R180"/>
 <pin name="A2" x="12.7" y="2.54" length="short" rot="R180"/>
@@ -7511,9 +7511,9 @@ Shield form compatible with the Arduino Uno R3.
 <connect gate="G$1" pin="*5" pad="8"/>
 <connect gate="G$1" pin="*6" pad="9"/>
 <connect gate="G$1" pin="*9" pad="12"/>
-<connect gate="G$1" pin="11(MOSI)" pad="14"/>
-<connect gate="G$1" pin="12(MISO)" pad="15"/>
-<connect gate="G$1" pin="13(SCK)" pad="16"/>
+<connect gate="G$1" pin="14(MISO)" pad="15"/>
+<connect gate="G$1" pin="15(SCK)" pad="16"/>
+<connect gate="G$1" pin="16(MOSI)" pad="14"/>
 <connect gate="G$1" pin="2" pad="5"/>
 <connect gate="G$1" pin="4" pad="7"/>
 <connect gate="G$1" pin="7" pad="10"/>


### PR DESCRIPTION
Updated the Pro Micro schematic to correctly identify pin pads 14, 15, and 16 to match silk screen and mapping within Sparkfun Arduino IDE board manager.