### PR TITLE
Fix name of nRF52832 breakout board

### DIFF
--- a/SparkFun-Boards.lbr
+++ b/SparkFun-Boards.lbr
@@ -4999,14 +4999,14 @@ Footprint for mating with Edison SBC.
 <hole x="17.78" y="15.24" drill="3.048"/>
 </package>
 <package name="SPARKFUN_NRF52832_BREAKOUT">
-<description>&lt;h3&gt;SparkFun nRF42832 Breakout&lt;/h3&gt;
+<description>&lt;h3&gt;SparkFun nRF52832 Breakout&lt;/h3&gt;
 &lt;p&gt;Specifications:
 &lt;ul&gt;&lt;li&gt;Pin count:42&lt;/li&gt;
 &lt;li&gt;Pin pitch: 0.1"&lt;/li&gt;
 &lt;li&gt;Area: 0.7x2.05&lt;/li&gt;
 &lt;/ul&gt;&lt;/p&gt;
 &lt;p&gt;Example device(s):
-&lt;ul&gt;&lt;li&gt;SPARKFUN_NRF42832_BREAKOUT&lt;/li&gt;
+&lt;ul&gt;&lt;li&gt;SPARKFUN_NRF52832_BREAKOUT&lt;/li&gt;
 &lt;/ul&gt;&lt;/p&gt;</description>
 <wire x1="0" y1="0" x2="0" y2="52.07" width="0.2032" layer="21"/>
 <wire x1="0" y1="52.07" x2="17.78" y2="52.07" width="0.2032" layer="21"/>


### PR DESCRIPTION
There is no nRF42832.