### PR TITLE
Update SparkFun-Resistors.lbr

### DIFF
--- a/SparkFun-Resistors.lbr
+++ b/SparkFun-Resistors.lbr
@@ -2325,7 +2325,7 @@ It has a reduced top mask to make it harder to install upside-down.</description
 </connects>
 <technologies>
 <technology name="">
-<attribute name="PROD_ID" value="RES-08595"/>
+<attribute name="PROD_ID" value="RES-14417"/>
 <attribute name="VALUE" value="30.1k"/>
 </technology>
 </technologies>


### PR DESCRIPTION
Updating the PROD_ID for the 30.1k 0603 resistor:
The old PROD_ID was 08595 - now retired.
Updating this with 14417.

PaulZC