### PR TITLE
Renamed Prefix.

### DIFF
--- a/SparkFun-PowerSymbols.lbr
+++ b/SparkFun-PowerSymbols.lbr
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="9.4.2">
+<eagle version="9.6.2">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
@@ -744,7 +744,7 @@ You are welcome to use this library for commercial purposes. For attribution, we
 </device>
 </devices>
 </deviceset>
-<deviceset name="2PT_GND_TIE" prefix="SUPPLY">
+<deviceset name="2PT_GND_TIE" prefix="SUPPLYTIE">
 <description>&lt;h3&gt;Dual Ground Supply&lt;/h3&gt;
 &lt;p&gt;Power supply symbol for connecting two grounds.&lt;/p&gt;
 &lt;p&gt;SparkFun Products:


### PR DESCRIPTION
2PT_GND_TIE had a prefix of 'SUPPLY' and had a footprint/package. You can't renumber sheets while having parts with and without packages with the same prefix.