### PR TITLE
Add tRestrict to all uSD connectors

### DIFF
--- a/SparkFun-Connectors.lbr
+++ b/SparkFun-Connectors.lbr
@@ -12761,6 +12761,8 @@ Puhs-Push type.
 <text x="0.635" y="15.875" size="1.27" layer="51" font="vector" ratio="10" align="center-left">Pressed</text>
 <text x="0.635" y="17.78" size="1.27" layer="51" font="vector" ratio="10" align="center-left">Locked</text>
 <text x="0.635" y="20.955" size="1.27" layer="51" font="vector" ratio="10" align="center-left">Unlocked</text>
+<rectangle x1="-13.97" y1="0" x2="0" y2="15.24" layer="39"/>
+<rectangle x1="-11.43" y1="15.24" x2="0" y2="27.94" layer="39"/>
 </package>
 <package name="DIL28-3-ZIF_SOCKET">
 <description>&lt;h3&gt;ZIF Socket 28-Pin 0.3"&lt;/h3&gt;
@@ -19167,6 +19169,8 @@ Package can be used as basic guideline for creating Edison-mating daughter board
 <text x="14.605" y="15.875" size="1.27" layer="51" font="vector" ratio="10" align="center-left">Pressed</text>
 <text x="14.605" y="17.78" size="1.27" layer="51" font="vector" ratio="10" align="center-left">Locked</text>
 <text x="14.605" y="20.955" size="1.27" layer="51" font="vector" ratio="10" align="center-left">Unlocked</text>
+<rectangle x1="0" y1="0" x2="13.97" y2="15.24" layer="39"/>
+<rectangle x1="2.54" y1="15.24" x2="13.97" y2="27.94" layer="39"/>
 </package>
 <package name="1X02_POKEHOME">
 <description>2 pin poke-home connector
@@ -26281,6 +26285,8 @@ Reversed pinout to match Raspberry Pi male header pinout when coupled.</descript
 <text x="-2.54" y="0" size="0.8128" layer="25">&gt;Name</text>
 <text x="-2.54" y="-1.27" size="0.8128" layer="27">&gt;Value</text>
 <rectangle x1="-4.484" y1="-1.984" x2="4.052" y2="1.926" layer="41"/>
+<rectangle x1="-5.588" y1="-2.921" x2="5.588" y2="3.429" layer="39"/>
+<rectangle x1="-5.08" y1="-16.51" x2="5.842" y2="-2.921" layer="39"/>
 </package>
 <package name="USB-MICROB-PTH-MILL">
 <smd name="SHIELD7" x="2.72858125" y="-2.53091875" dx="2.1" dy="1.4" layer="16" roundness="100" rot="R90" stop="no" cream="no"/>
@@ -39066,6 +39072,8 @@ Alternate pin configuration
 <wire x1="-7.2" y1="2" x2="-7.2" y2="8.5" width="0.2032" layer="21"/>
 <text x="0" y="1" size="0.5" layer="25" align="center">&gt;Name</text>
 <text x="0" y="0" size="0.5" layer="27" align="center">&gt;Value</text>
+<rectangle x1="-7.239" y1="-4.064" x2="7.239" y2="10.541" layer="39"/>
+<rectangle x1="-6.477" y1="-16.51" x2="4.572" y2="-4.064" layer="39"/>
 </package>
 <package name="FPC_16_0.5MM_VERTICAL">
 <wire x1="6.45" y1="-1.15" x2="-6.45" y2="-1.15" width="0.1" layer="51"/>


### PR DESCRIPTION
Will give DRC errors if designer tries to add components where the uSD card slides into the connector