### PR TITLE
Removed NC Pins from V-REG-LDO_NO-BP sym.

### DIFF
--- a/SparkFun-IC-Power.lbr
+++ b/SparkFun-IC-Power.lbr
@@ -7,7 +7,7 @@
 <setting keepoldvectorfont="yes"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="no" altdistance="0.01" altunitdist="inch" altunit="inch"/>
+<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.01" altunitdist="inch" altunit="inch"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="16" name="Bottom" color="1" fill="1" visible="yes" active="yes"/>
@@ -2907,7 +2907,6 @@ Pasted was reduced by 40% width on the center ground pad, and some amount on the
 <pin name="GND" x="-10.16" y="-5.08" visible="pin" length="short" direction="in"/>
 <pin name="OUT" x="7.62" y="5.08" visible="pin" length="short" direction="pas" rot="R180"/>
 <pin name="EN" x="-10.16" y="0" visible="pin" length="short" direction="in"/>
-<pin name="NC" x="7.62" y="-5.08" visible="pin" length="short" direction="nc" rot="R180"/>
 </symbol>
 <symbol name="LTC4150">
 <wire x1="-10.16" y1="12.7" x2="-10.16" y2="-10.16" width="0.254" layer="94"/>
@@ -3957,7 +3956,6 @@ Iq less than 1uA for low Iload</description>
 <connect gate="U1" pin="EN" pad="3"/>
 <connect gate="U1" pin="GND" pad="2"/>
 <connect gate="U1" pin="IN" pad="1"/>
-<connect gate="U1" pin="NC" pad="4"/>
 <connect gate="U1" pin="OUT" pad="5"/>
 </connects>
 <technologies>
@@ -4185,7 +4183,6 @@ See a 3.3V fixed output version of this chip in action on the &lt;a href="https:
 <connect gate="G$1" pin="EN" pad="3"/>
 <connect gate="G$1" pin="GND" pad="2"/>
 <connect gate="G$1" pin="IN" pad="1"/>
-<connect gate="G$1" pin="NC" pad="4"/>
 <connect gate="G$1" pin="OUT" pad="5"/>
 </connects>
 <technologies>
@@ -4309,7 +4306,6 @@ This high-voltage regulator contains an N-Channel Buck switch, a startup regulat
 <connect gate="G$1" pin="EN" pad="3"/>
 <connect gate="G$1" pin="GND" pad="2"/>
 <connect gate="G$1" pin="IN" pad="1"/>
-<connect gate="G$1" pin="NC" pad="4"/>
 <connect gate="G$1" pin="OUT" pad="5"/>
 </connects>
 <technologies>
@@ -4733,7 +4729,6 @@ Specifications:
 <connect gate="G$1" pin="EN" pad="3"/>
 <connect gate="G$1" pin="GND" pad="2"/>
 <connect gate="G$1" pin="IN" pad="1"/>
-<connect gate="G$1" pin="NC" pad="4"/>
 <connect gate="G$1" pin="OUT" pad="5"/>
 </connects>
 <technologies>
@@ -5150,7 +5145,6 @@ to –40V.</description>
 <connect gate="U1" pin="EN" pad="3"/>
 <connect gate="U1" pin="GND" pad="2"/>
 <connect gate="U1" pin="IN" pad="1"/>
-<connect gate="U1" pin="NC" pad="4"/>
 <connect gate="U1" pin="OUT" pad="5"/>
 </connects>
 <technologies>
@@ -5271,7 +5265,6 @@ from 1.2 V to 4.5 V in 25-mV steps.&lt;/p&gt;</description>
 <connect gate="G$1" pin="EN" pad="3"/>
 <connect gate="G$1" pin="GND" pad="2"/>
 <connect gate="G$1" pin="IN" pad="1"/>
-<connect gate="G$1" pin="NC" pad="4"/>
 <connect gate="G$1" pin="OUT" pad="5"/>
 </connects>
 <technologies>
@@ -5359,7 +5352,6 @@ from 1.2 V to 4.5 V in 25-mV steps.&lt;/p&gt;</description>
 <connect gate="G$1" pin="EN" pad="3"/>
 <connect gate="G$1" pin="GND" pad="2"/>
 <connect gate="G$1" pin="IN" pad="1"/>
-<connect gate="G$1" pin="NC" pad="4"/>
 <connect gate="G$1" pin="OUT" pad="5"/>
 </connects>
 <technologies>


### PR DESCRIPTION
This affects the following parts:
ADP160
STLQ015
V_REG_AP2112
V_REG_AP2127
V_REG_LP5907
V_REG_SP6214
XC6222

No electrical change, this is just to remove clutter.