### PR TITLE
Update SparkFun-MicroMod.lbr

### DIFF
--- a/SparkFun-MicroMod.lbr
+++ b/SparkFun-MicroMod.lbr
@@ -5568,8 +5568,8 @@ sized tool</text>
 <pin name="3.3V" x="-17.78" y="25.4" length="short"/>
 <pin name="USBHOST_D+" x="-17.78" y="-7.62" length="short"/>
 <pin name="USBHOST_D-" x="-17.78" y="-5.08" length="short"/>
-<pin name="CAN-RX" x="-17.78" y="-15.24" length="short"/>
-<pin name="CAN-TX" x="-17.78" y="-12.7" length="short"/>
+<pin name="CAN-TX" x="-17.78" y="-15.24" length="short"/>
+<pin name="CAN-RX" x="-17.78" y="-12.7" length="short"/>
 <pin name="I2C_SCL" x="17.78" y="12.7" length="short" rot="R180"/>
 <pin name="I2C_SDA" x="17.78" y="10.16" length="short" rot="R180"/>
 <pin name="F0/!INT!" x="17.78" y="-12.7" length="short" rot="R180"/>
@@ -5760,8 +5760,8 @@ sized tool</text>
 <connects>
 <connect gate="J1" pin="3.3V" pad="73"/>
 <connect gate="J1" pin="A0" pad="38"/>
-<connect gate="J1" pin="CAN-RX" pad="41"/>
-<connect gate="J1" pin="CAN-TX" pad="43"/>
+<connect gate="J1" pin="CAN-RX" pad="43"/>
+<connect gate="J1" pin="CAN-TX" pad="41"/>
 <connect gate="J1" pin="CTS" pad="18"/>
 <connect gate="J1" pin="DFU_!ACTIVE!" pad="10"/>
 <connect gate="J1" pin="DFU_!BOOT!" pad="66"/>
@@ -5804,8 +5804,8 @@ sized tool</text>
 <connects>
 <connect gate="J1" pin="3.3V" pad="73"/>
 <connect gate="J1" pin="A0" pad="38"/>
-<connect gate="J1" pin="CAN-RX" pad="41"/>
-<connect gate="J1" pin="CAN-TX" pad="43"/>
+<connect gate="J1" pin="CAN-RX" pad="43"/>
+<connect gate="J1" pin="CAN-TX" pad="41"/>
 <connect gate="J1" pin="CTS" pad="18"/>
 <connect gate="J1" pin="DFU_!ACTIVE!" pad="10"/>
 <connect gate="J1" pin="DFU_!BOOT!" pad="66"/>


### PR DESCRIPTION
-Swap labels on MicroMod Function Board symbol so that CAN-RX and CAN-TX are connected correctly.