### PR TITLE
Adds new USB MUX switch

### DIFF
--- a/SparkFun-IC-Special-Function.lbr
+++ b/SparkFun-IC-Special-Function.lbr
@@ -7,7 +7,7 @@
 <setting keepoldvectorfont="yes"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.05" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.005" altunitdist="inch" altunit="inch"/>
+<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.01" altunitdist="inch" altunit="inch"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="16" name="Bottom" color="1" fill="1" visible="yes" active="yes"/>
@@ -4537,6 +4537,15 @@ package with digital interface.&lt;/p&gt;
 <wire x1="1.197353125" y1="-0.7467625" x2="1.781553125" y2="-0.7467625" width="0.2032" layer="31"/>
 </package>
 <package name="MSOP10">
+<description>&lt;h3&gt;MSOP10&lt;/h3&gt;
+&lt;p&gt;Mechanical Specifications:
+&lt;ul&gt;
+&lt;li&gt;Pad Size:1.4mm x .3mm&lt;/li&gt;
+&lt;li&gt;Pin count: 10&lt;/li&gt;
+&lt;li&gt;Pin pitch: .5mm&lt;/li&gt;
+&lt;li&gt;Package Size: 3mm x 3mm &lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;
+&lt;p&gt;&lt;a href=”https://rocelec.widen.net/view/pdf/a7amyaouts/FAIR-S-A0001171768-1.pdf?t.download=true&amp;u=5oefqw”&gt;Datasheet referenced for footprint&lt;/a&gt;&lt;/p&gt;</description>
 <wire x1="-1.5" y1="1.5" x2="-1.5" y2="-1.5" width="0.127" layer="51"/>
 <wire x1="-1.5" y1="-1.5" x2="1.5" y2="-1.5" width="0.2032" layer="21"/>
 <wire x1="1.5" y1="-1.5" x2="1.5" y2="1.5" width="0.127" layer="51"/>
@@ -6669,6 +6678,24 @@ The TLC5947 has a thermal shutdown (TSD) function that turns off all output driv
 <pin name="USB_DP" x="-17.78" y="-20.32" length="short"/>
 <pin name="USB_DM" x="-17.78" y="-22.86" length="short"/>
 </symbol>
+<symbol name="FSUSB42MUX">
+<wire x1="-7.62" y1="-10.16" x2="7.62" y2="-10.16" width="0.4064" layer="94"/>
+<wire x1="7.62" y1="-10.16" x2="7.62" y2="10.16" width="0.4064" layer="94"/>
+<wire x1="7.62" y1="10.16" x2="-7.62" y2="10.16" width="0.4064" layer="94"/>
+<wire x1="-7.62" y1="10.16" x2="-7.62" y2="-10.16" width="0.4064" layer="94"/>
+<pin name="D2-" x="10.16" y="-5.08" visible="pin" length="short" rot="R180"/>
+<pin name="D2+" x="10.16" y="-2.54" visible="pin" length="short" rot="R180"/>
+<pin name="GND" x="-10.16" y="-7.62" visible="pin" length="short"/>
+<pin name="!OE!" x="-10.16" y="-5.08" visible="pin" length="short"/>
+<pin name="D1-" x="10.16" y="2.54" visible="pin" length="short" rot="R180"/>
+<pin name="D1+" x="10.16" y="5.08" visible="pin" length="short" rot="R180"/>
+<pin name="D+" x="-10.16" y="2.54" visible="pin" length="short"/>
+<pin name="D-" x="-10.16" y="0" visible="pin" length="short"/>
+<pin name="SEL" x="-10.16" y="-2.54" visible="pin" length="short"/>
+<pin name="VCC" x="-10.16" y="7.62" visible="pin" length="short"/>
+<text x="-7.62" y="10.795" size="1.778" layer="95" font="vector">&gt;NAME</text>
+<text x="-7.62" y="-12.7" size="1.778" layer="96" font="vector">&gt;VALUE</text>
+</symbol>
 </symbols>
 <devicesets>
 <deviceset name="AD5262">
@@ -8783,6 +8810,38 @@ Source: &lt;a href="https://ww1.microchip.com/downloads/en/DeviceDoc/00001979A.p
 <technologies>
 <technology name="">
 <attribute name="PROD_ID" value="IC-16527" constant="no"/>
+</technology>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="FSUSB42MUX">
+<description>&lt;h3&gt;Fairchild FSUSB42MUX&lt;/h3&gt;
+&lt;p&gt;he FSUSB42 is a bi-directional, low-power, two-port,
+high-speed, USB2.0 switch. Configured as a double-
+pole, double-throw switch (DPDT) switch, it is optimized
+for switching between any combination of high-speed
+(480 Mbps) or Full-Speed (12 Mbps) sources.&lt;/p&gt;</description>
+<gates>
+<gate name="G$1" symbol="FSUSB42MUX" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="MSOP10">
+<connects>
+<connect gate="G$1" pin="!OE!" pad="10"/>
+<connect gate="G$1" pin="D+" pad="3"/>
+<connect gate="G$1" pin="D-" pad="4"/>
+<connect gate="G$1" pin="D1+" pad="7"/>
+<connect gate="G$1" pin="D1-" pad="6"/>
+<connect gate="G$1" pin="D2+" pad="9"/>
+<connect gate="G$1" pin="D2-" pad="8"/>
+<connect gate="G$1" pin="GND" pad="5"/>
+<connect gate="G$1" pin="SEL" pad="2"/>
+<connect gate="G$1" pin="VCC" pad="1"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="IC-18702" constant="no"/>
 </technology>
 </technologies>
 </device>


### PR DESCRIPTION
This part is the newer iteration of the FSUSB30 which is now obsolete. Unfortunately it is not a direct drop in replacement, some pins have been rearranged but the package is exactly the same. 