### PR TITLE
Added 1.8V version of RT9080; updated RT9080 3.3V version name

### DIFF
--- a/SparkFun-IC-Power.lbr
+++ b/SparkFun-IC-Power.lbr
@@ -7,7 +7,7 @@
 <setting keepoldvectorfont="yes"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="no" altdistance="0.01" altunitdist="inch" altunit="inch"/>
+<grid distance="0.05" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.005" altunitdist="inch" altunit="inch"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="16" name="Bottom" color="1" fill="1" visible="yes" active="yes"/>
@@ -5676,7 +5676,19 @@ MOSFET to provide high-efficiency step-down DC-DC conversion.</description>
 </device>
 </devices>
 </deviceset>
-<deviceset name="V_REG_RT9080" prefix="U">
+<deviceset name="V_REG_RT9080-33GJ5" prefix="U">
+<description>&lt;H3&gt;RT9080-33GJ5 Low-Dropout Linear Regulator&lt;/H3&gt;
+&lt;p&gt;The RT9080 is a low-dropout (LDO) voltage regulators with
+enable function that operates from 1.2V to 5.5V. It provides
+up to 600mA of output current and offers low-power
+operation in miniaturized packaging.
+
+&lt;p&gt;The features of low quiescent current as low as 2μA and
+almost zero disable current is ideal for powering the battery
+equipment to a longer service life. The RT9080 is stable
+with the ceramic output capacitor over its wide input range
+from 1.2V to 5.5V and the entire range of output load
+current (0mA to 600mA). The output for this LDO is 3.3V.</description>
 <gates>
 <gate name="G$1" symbol="V-REG-LDO_NO-BP" x="0" y="0"/>
 </gates>
@@ -5718,6 +5730,39 @@ URB2405YMD-15WR3: Input 24V (9V-36V), Output 5.0V 3.0A</description>
 <technology name="">
 <attribute name="PROD_ID" value="COMP-19263" constant="no"/>
 <attribute name="VALUE" value="URB2405YMD" constant="no"/>
+</technology>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="V_REG_RT9080-18GJ5">
+<description>&lt;H3&gt;RT9080-18GJ5 Low-Dropout Linear Regulator&lt;/H3&gt;
+&lt;p&gt;The RT9080 is a low-dropout (LDO) voltage regulators with
+enable function that operates from 1.2V to 5.5V. It provides
+up to 600mA of output current and offers low-power
+operation in miniaturized packaging.
+
+&lt;p&gt;The features of low quiescent current as low as 2μA and
+almost zero disable current is ideal for powering the battery
+equipment to a longer service life. The RT9080 is stable
+with the ceramic output capacitor over its wide input range
+from 1.2V to 5.5V and the entire range of output load
+current (0mA to 600mA). The output for this LDO is 1.8V.</description>
+<gates>
+<gate name="G$1" symbol="V-REG-LDO_NO-BP" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="SOT23-5">
+<connects>
+<connect gate="G$1" pin="EN" pad="3"/>
+<connect gate="G$1" pin="GND" pad="2"/>
+<connect gate="G$1" pin="IN" pad="1"/>
+<connect gate="G$1" pin="OUT" pad="5"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="VREG-21045" constant="no"/>
+<attribute name="VALUE" value="RT9080-18GJ5" constant="no"/>
 </technology>
 </technologies>
 </device>


### PR DESCRIPTION
A description was added for both parts, and the name was updated for the 3.3V version. The 1.8V version of the part was also added to the library for general use.